### PR TITLE
Add aggregation layer (aka linear layer)

### DIFF
--- a/clebsch_gordan.py
+++ b/clebsch_gordan.py
@@ -1,7 +1,7 @@
 from functools import lru_cache
 import e3nn_jax
 
-from utils import to_cartesian_order_idx
+from utils.spherical_harmonics_utils import to_cartesian_order_idx
 
 
 def get_clebsch_gordan(l1: int, l2: int, l3: int, m1: int, m2: int, m3: int) -> float:
@@ -10,10 +10,12 @@ def get_clebsch_gordan(l1: int, l2: int, l3: int, m1: int, m2: int, m3: int) -> 
     m3_idx = to_cartesian_order_idx(l3, m3)
     return _get_clebsch_gordan(l1, l2, l3)[m1_idx, m2_idx, m3_idx]
 
+
 @lru_cache(maxsize=None)
 def _get_clebsch_gordan(l1: int, l2: int, l_out: int) -> str:
     return e3nn_jax.clebsch_gordan(l1, l2, l_out)
 
+
 if __name__ == "__main__":
     print(e3nn_jax.clebsch_gordan(1, 1, 2))
-    print(e3nn_jax.clebsch_gordan(1, 1, 2).shape) # this has shape (3,3,5)
+    print(e3nn_jax.clebsch_gordan(1, 1, 2).shape)  # this has shape (3,3,5)

--- a/geometric_utils.py
+++ b/geometric_utils.py
@@ -3,7 +3,10 @@ import numpy as np
 
 from irrep import Irreps
 
-def to_graph(positions: list[float], cutoff_radius: int, nodes_have_self_connections: bool) -> tuple[np.ndarray, np.ndarray]:
+
+def to_graph(
+    positions: list[float], cutoff_radius: int, nodes_have_self_connections: bool
+) -> tuple[np.ndarray, np.ndarray]:
     """
     Converts a point cloud into a graph based on a cutoff radius.
 
@@ -36,10 +39,13 @@ def to_graph(positions: list[float], cutoff_radius: int, nodes_have_self_connect
 
     return source_indices, target_indices
 
+
 # used when we want to aggregate all of the irreps coming from neighbouring nodes (right after when the messages are passed)
 def avg_irreps_with_same_id(irreps_list: list[Irreps]) -> Irreps:
     ids = [irreps.id() for irreps in irreps_list]
-    assert len(set(ids)) == 1, f"Not all irreps in irreps_list are the same. ids = {ids}"
+    assert (
+        len(set(ids)) == 1
+    ), f"All ids for irreps in irreps_list MUST be the same (so we can avg them). ids: {ids}"
 
     # the first irreps will be where we store the averaged irreps
     summed_data = irreps_list[0].data()
@@ -49,4 +55,4 @@ def avg_irreps_with_same_id(irreps_list: list[Irreps]) -> Irreps:
 
     for i in range(len(summed_data)):
         summed_data[i] /= len(irreps_list)
-    return Irreps.from_id(irreps.id(), summed_data)
+    return Irreps.from_id(irreps_list[0].id(), summed_data)

--- a/irrep.py
+++ b/irrep.py
@@ -41,6 +41,7 @@ class Irreps:
         ), f"the number of irreps ({len(irreps)}) must match the number of data tensors ({len(data)})"
         return Irreps(irreps)
 
+    # TODO(curtis): should these irreps be sorted?
     @staticmethod
     def parse_id(id: str) -> Generator[tuple[int, int, int], None, None]: # yields (irrep_def, num_irreps, l, parity)
         irreps_defs = id.split("+")
@@ -128,7 +129,8 @@ class Irreps:
         self.irreps = self._sort_irreps(new_irreps)
 
     def convert_to_representation_with_learnable_weights(self, new_representation_id: str):
-        pass
+        for representation in Irreps.parse_id(new_representation_id):
+            pass
 
 @dataclasses.dataclass(init=False)
 class Irrep:

--- a/irrep.py
+++ b/irrep.py
@@ -7,7 +7,7 @@ import re
 
 from clebsch_gordan import get_clebsch_gordan
 from constants import EVEN_PARITY, ODD_PARITY
-from utils import to_cartesian_order_idx
+from utils.spherical_harmonics_utils import to_cartesian_order_idx
 
 
 class Irreps:

--- a/irrep.py
+++ b/irrep.py
@@ -114,6 +114,9 @@ class Irreps:
     def data_flattened_tensor(self) -> torch.Tensor:
         return torch.cat([irrep.data.flatten() for irrep in self.irreps])
 
+    def get_irreps_by_id(self, id: str) -> list[Irrep]:
+        return [irrep for irrep in self.irreps if irrep.id() == id]
+
     ###########################################################################
     # GNN Utils
     # These are utils that are used by the neural network framework to actually make predictions from the irreps

--- a/irrep.py
+++ b/irrep.py
@@ -41,13 +41,17 @@ class Irreps:
         ), f"the number of irreps ({len(irreps)}) must match the number of data tensors ({len(data)})"
         return Irreps(irreps)
 
-    # TODO(curtis): should these irreps be sorted?
     @staticmethod
-    def parse_id(id: str) -> Generator[tuple[int, int, int], None, None]: # yields (irrep_def, num_irreps, l, parity)
+    def parse_id(
+        id: str,
+    ) -> Generator[
+        tuple[int, int, int], None, None
+    ]:  # yields (irrep_def, num_irreps, l, parity)
         irreps_defs = id.split("+")
         irreps_defs = [irrep_def.strip() for irrep_def in irreps_defs]
         irreps_pattern = r"^(\d+)x+(\d+)([eo])$"
 
+        irrep_parts = []
         for irrep_def in irreps_defs:
             # create irreps from the string
             match = re.match(irreps_pattern, irrep_def)
@@ -59,7 +63,11 @@ class Irreps:
 
             l = int(l_str)
             parity = ODD_PARITY if parity_str == "o" else EVEN_PARITY
-            yield (irrep_def, int(num_irreps), l, parity)
+            irrep_parts.append((irrep_def, int(num_irreps), l, parity))
+        for parts in sorted(
+            irrep_parts, key=lambda x: (x[2], x[3])
+        ):  # sort by l and parity
+            yield parts
 
     def __repr__(self) -> str:
         return f"{self.id()}: {str(self.data_flattened())}"
@@ -102,10 +110,10 @@ class Irreps:
         for irrep in self.irreps:
             consolidated_data.extend(irrep.data.tolist())
         return consolidated_data
-    
+
     def data_flattened_tensor(self) -> torch.Tensor:
         return torch.cat([irrep.data.flatten() for irrep in self.irreps])
-    
+
     ###########################################################################
     # GNN Utils
     # These are utils that are used by the neural network framework to actually make predictions from the irreps
@@ -119,7 +127,7 @@ class Irreps:
         id_to_representation = defaultdict(list[Irrep])
         for irrep in self.irreps:
             id_to_representation[irrep.id()].append(irrep)
-        
+
         new_irreps = []
         for representations in id_to_representation.values():
             num_representation = len(representations)
@@ -131,9 +139,12 @@ class Irreps:
             new_irreps.append(representations[0])
         self.irreps = self._sort_irreps(new_irreps)
 
-    def convert_to_representation_with_learnable_weights(self, new_representation_id: str):
+    def convert_to_representation_with_learnable_weights(
+        self, new_representation_id: str
+    ):
         for representation in Irreps.parse_id(new_representation_id):
             pass
+
 
 @dataclasses.dataclass(init=False)
 class Irrep:
@@ -219,8 +230,12 @@ class Irrep:
     # e.g. 2o means it's for spherical harmonics of degree 2 (l=2) and parity=odd
     # since l=2, there are 2*2 + 1 = 5 coefficients that this irrep stores in its data array
     def id(self):
-        if self.parity == 1:
+        return Irrep.to_id(self.l, self.parity)
+
+    @staticmethod
+    def to_id(l: int, parity: int) -> str:
+        if parity == 1:
             parity_str = "e"
-        elif self.parity == -1:
+        elif parity == -1:
             parity_str = "o"
-        return f"{self.l}{parity_str}"
+        return f"{l}{parity_str}"

--- a/irrep.py
+++ b/irrep.py
@@ -103,6 +103,9 @@ class Irreps:
             consolidated_data.extend(irrep.data.tolist())
         return consolidated_data
     
+    def data_flattened_tensor(self) -> torch.Tensor:
+        return torch.cat([irrep.data.flatten() for irrep in self.irreps])
+    
     ###########################################################################
     # GNN Utils
     # These are utils that are used by the neural network framework to actually make predictions from the irreps

--- a/irrep_test.py
+++ b/irrep_test.py
@@ -1,20 +1,10 @@
 from constants import EVEN_PARITY, ODD_PARITY
-from irrep import Irrep, Irreps
-import torch
+from irrep import Irrep
+from utils.dummy_data_utils import create_irreps_with_dummy_data, dummy_data
+
 
 # the purpose of this file is to ensure that the tensor product produces the correct irreps
 # read the last section of this file to understand how tensor products work
-
-
-def dummy_data(l: int) -> torch.Tensor:
-    # creates dummy data for a specific l value
-    arr = torch.zeros(2 * l + 1)
-    arr[0] = 1  # so the array is normalized to length 1
-    return arr
-
-
-def dummy_data_for_multiple_irreps(l_list: list[int]) -> torch.Tensor:
-    return [dummy_data(l) for l in l_list]
 
 
 def test_irrep_id():
@@ -31,15 +21,11 @@ def test_irrep_id():
 
 def test_irreps_id():
     assert (
-        Irreps.from_id(
-            "1x1e + 1x1o + 2x2e+2x2o",
-            dummy_data_for_multiple_irreps([1, 1, 2, 2, 2, 2]),
-        ).id()
+        create_irreps_with_dummy_data("1x1e + 1x1o + 2x2e+2x2o").id()
         == "1x1o+1x1e+2x2o+2x2e"
     )
     assert (
-        Irreps.from_id("1x1e + 1x1e", dummy_data_for_multiple_irreps([1, 1])).id()
-        == "2x1e"
+        create_irreps_with_dummy_data("1x1e + 1x1e").id() == "2x1e"
     )  # test consolidating irreps
 
 
@@ -63,20 +49,16 @@ def test_irrep_tensor_product():
 
     # if we take the direct sum of the produced irreps, we get: 2x0e + 2x1o + 1x1e + 1x2e
     assert (
-        Irreps.from_id("1x0e+1x1o", dummy_data_for_multiple_irreps([0, 1]))
-        .tensor_product(
-            Irreps.from_id("1x0e+1x1o", dummy_data_for_multiple_irreps([0, 1]))
-        )
+        create_irreps_with_dummy_data("1x0e+1x1o")
+        .tensor_product(create_irreps_with_dummy_data("1x0e+1x1o"))
         .id()
         == "2x0e+2x1o+1x1e+1x2e"
     )
 
     # this next tensor product test is here just to ensure my code works
     assert (
-        Irreps.from_id("1x0e+1x1o+1x2e", dummy_data_for_multiple_irreps([0, 1, 2]))
-        .tensor_product(
-            Irreps.from_id("1x0e+1x1o+1x2e", dummy_data_for_multiple_irreps([0, 1, 2]))
-        )
+        create_irreps_with_dummy_data("1x0e+1x1o+1x2e")
+        .tensor_product(create_irreps_with_dummy_data("1x0e+1x1o+1x2e"))
         .id()
         == "3x0e+4x1o+2x1e+2x2o+4x2e+2x3o+1x3e+1x4e"
     )

--- a/model2.py
+++ b/model2.py
@@ -13,15 +13,17 @@ from utils.dummy_data_utils import create_irreps_with_dummy_data
 class Model(torch.nn.Module):
     def __init__(self):
         super().__init__()
-        # TODO: we should automatically determine the id in the intermediate linear layer based on the id passed into the input of the Layer
-        self.layer1 = Layer("1x0e + ", 20)
+        self.starting_irreps_id = "1x0e"  # each node starts with a dummy 1x0e irrep
+        self.layer1 = Layer(self.starting_irreps_id, "1x0e, 1x1o")
         self.radius = 1.1
 
     def forward(self, positions):
         num_nodes = len(positions)
         starting_irreps = []
         for _ in range(num_nodes):
-            starting_irreps.append(Irreps.from_id("1x0e", [torch.ones(1)]))
+            starting_irreps.append(
+                create_irreps_with_dummy_data(self.starting_irreps_id)
+            )
 
         edge_index = to_graph(
             positions, cutoff_radius=1.5, nodes_have_self_connections=False

--- a/model2.py
+++ b/model2.py
@@ -14,7 +14,7 @@ class Model(torch.nn.Module):
     def __init__(self):
         super().__init__()
         self.starting_irreps_id = "1x0e"  # each node starts with a dummy 1x0e irrep
-        self.layer1 = Layer(self.starting_irreps_id, "1x0e, 1x1o")
+        self.layer1 = Layer(self.starting_irreps_id, "1x0e + 1x1o")
         self.radius = 1.1
 
     def forward(self, positions):
@@ -53,7 +53,7 @@ class LinearLayer(torch.nn.Module):
         self.unique_output_ids = defaultdict(int)
         self.sorted_output_ids: list[(str, int, int)] = []
         self.weights: list[torch.Tensor] = []
-        for _irrep_def, num_irreps, l, _parity in Irreps.parse_id(output_irreps_id):
+        for _irrep_def, num_irreps, l, parity in Irreps.parse_id(output_irreps_id):
             irrep_id = Irrep.to_id(l, parity)
             self.sorted_output_ids.append((irrep_id, l, parity))
             num_output_coefficients += num_irreps * (2 * l + 1)
@@ -105,8 +105,8 @@ class Layer(torch.nn.Module):
         # perform a dummy tensor product to get the irreps_id going into the linear layer after
         # the tensor product layer
         sh_dummy_irreps = map_3d_feats_to_spherical_harmonics_repr(
-            torch.tensor([[1, 0, 0]]), self.sh_lmax
-        )
+            torch.tensor([[1.0, 0.0, 0.0]]), self.sh_lmax
+        )[0]
         input_dummy_irreps = create_irreps_with_dummy_data(input_irreps_id)
         return input_dummy_irreps.tensor_product(sh_dummy_irreps).id()
 

--- a/model2.py
+++ b/model2.py
@@ -7,6 +7,8 @@ from irrep import Irrep, Irreps
 from spherical_harmonics import map_3d_feats_to_spherical_harmonics_repr
 import numpy as np
 
+from utils.dummy_data_utils import create_irreps_with_dummy_data
+
 
 class Model(torch.nn.Module):
     def __init__(self):
@@ -89,14 +91,22 @@ class Layer(torch.nn.Module):
         super(Layer, self).__init__()
         self.sh_lmax = sh_lmax
 
+        # Define linear layers.
+        irreps_id_after_tensor_product = self._get_irreps_id_after_tensor_product(
+            input_irreps_id
+        )
+        self.after_tensor_prod = LinearLayer(
+            irreps_id_after_tensor_product, output_irreps_id
+        )
 
+    def _get_irreps_id_after_tensor_product(self, input_irreps_id: str) -> str:
         # perform a dummy tensor product to get the irreps_id going into the linear layer after
         # the tensor product layer
-        sh_dummy_irreps = map_3d_feats_to_spherical_harmonics_repr(torch.tensor([[1,0,0]]), self.sh_lmax)
-        id_after_tensor_product =
-
-        # Define linear layers.
-        self.after_tensor_prod = LinearLayer(input_irreps_id, output_irreps_id)
+        sh_dummy_irreps = map_3d_feats_to_spherical_harmonics_repr(
+            torch.tensor([[1, 0, 0]]), self.sh_lmax
+        )
+        input_dummy_irreps = create_irreps_with_dummy_data(input_irreps_id)
+        return input_dummy_irreps.tensor_product(sh_dummy_irreps).id()
 
     def forward(
         self, x: list[Irreps], edge_index: tuple[np.ndarray, np.ndarray], positions

--- a/model2.py
+++ b/model2.py
@@ -11,8 +11,8 @@ import numpy as np
 class Model(torch.nn.Module):
     def __init__(self):
         super().__init__()
-        self.linear = torch.nn.Linear(4, 1)
-        self.layer1 = Layer(20, 20, 1)
+        # TODO: we should automatically determine the id in the intermediate linear layer based on the id passed into the input of the Layer
+        self.layer1 = Layer("1x0e + ", 20)
         self.radius = 1.1
 
     def forward(self, positions):
@@ -85,9 +85,15 @@ class LinearLayer(torch.nn.Module):
 
 
 class Layer(torch.nn.Module):
-    def __init__(self, input_irreps_id: str, output_irreps_id: str, sh_lmax=2):
+    def __init__(self, input_irreps_id: str, output_irreps_id: str, sh_lmax=1):
         super(Layer, self).__init__()
         self.sh_lmax = sh_lmax
+
+
+        # perform a dummy tensor product to get the irreps_id going into the linear layer after
+        # the tensor product layer
+        sh_dummy_irreps = map_3d_feats_to_spherical_harmonics_repr(torch.tensor([[1,0,0]]), self.sh_lmax)
+        id_after_tensor_product =
 
         # Define linear layers.
         self.after_tensor_prod = LinearLayer(input_irreps_id, output_irreps_id)

--- a/spherical_harmonics.py
+++ b/spherical_harmonics.py
@@ -6,7 +6,7 @@ import torch
 
 from irrep import Irrep, Irreps
 from spherical_harmonics_playground import _spherical_harmonics
-from utils import parity_for_l, to_cartesian_order_idx
+from utils.spherical_harmonics_utils import parity_for_l, to_cartesian_order_idx
 # from jax import jit
 
 # @jit
@@ -24,22 +24,28 @@ from utils import parity_for_l, to_cartesian_order_idx
 # the feature before mapping to a representation via spherical harmonics
 # This means that two vectors of different lengths but facing the same direction will have the same representation
 
+
 # If you look at the spherical harmonics here: http://openmopac.net/manual/real_spherical_harmonics.html, you'll see that each cartesian axis is raised to the same power
-def map_3d_feats_to_spherical_harmonics_repr(feats_3d: torch.tensor, max_l: int=2) -> list[Irreps]:
+def map_3d_feats_to_spherical_harmonics_repr(
+    feats_3d: torch.tensor, max_l: int = 2
+) -> list[Irreps]:
     irreps_out = []
     for feat in feats_3d:
         # ensure we're using cartesian order: https://e3x.readthedocs.io/stable/pitfalls.html
 
         irreps = []
         for l in range(max_l + 1):
-            coefficients = torch.zeros(2*l + 1)
+            coefficients = torch.zeros(2 * l + 1)
             for m in range(-l, l + 1):
-
                 # normalize the feature
                 magnitude = torch.linalg.norm(feat)
-                feat = (feat / magnitude)
+                feat = feat / magnitude
 
-                coefficient = float(_spherical_harmonics(l, m)(feat[0].item(), feat[1].item(), feat[2].item())) # assuming feat is [x,y,z]
+                coefficient = float(
+                    _spherical_harmonics(l, m)(
+                        feat[0].item(), feat[1].item(), feat[2].item()
+                    )
+                )  # assuming feat is [x,y,z]
                 # coefficient = float(e3x.so3._symbolic._spherical_harmonics(l, m)(*feat))
                 # coefficient = solid_harmonics(feat, l, cartesian_order=False)[m + l]
 
@@ -53,10 +59,11 @@ def map_3d_feats_to_spherical_harmonics_repr(feats_3d: torch.tensor, max_l: int=
 
     return irreps_out
 
+
 if __name__ == "__main__":
     distances = [
         [0, 0, 2],
         [0, 0, 4],
     ]
-    
+
     print(map_3d_feats_to_spherical_harmonics_repr(jnp.array(distances)))

--- a/tetris2.py
+++ b/tetris2.py
@@ -9,7 +9,6 @@ Exact equivariance to :math:`E(3)`
 import torch
 
 from model2 import Model
-from spherical_harmonics import map_3d_feats_to_spherical_harmonics_repr
 
 
 def tetris() -> None:
@@ -59,6 +58,7 @@ def tetris() -> None:
 
 #     return next(iter(DataLoader(dataset, batch_size=len(dataset))))
 
+
 def main() -> None:
     x, y = tetris()
     train_x, train_y = x[1:], y[1:]  # dont train on both chiral shapes
@@ -85,7 +85,13 @@ def main() -> None:
 
             if step % 10 == 0:
                 accuracy = (
-                    model(test_x).round().eq(test_y).all(dim=1).double().mean(dim=0).item()
+                    model(test_x)
+                    .round()
+                    .eq(test_y)
+                    .all(dim=1)
+                    .double()
+                    .mean(dim=0)
+                    .item()
                 )
                 print(
                     f"epoch {step:5d} | loss {loss:<10.1f} | {100 * accuracy:5.1f}% accuracy"

--- a/utils.py
+++ b/utils.py
@@ -9,6 +9,9 @@ def parity_for_l(l: int) -> int:
     # PERF: reduce this to one line
     # return (l % 2)*(-2) + 1
 
+def parity_to_str(parity: int) -> str:
+    return "e" if parity == EVEN_PARITY else "o"
+
 def to_cartesian_order_idx(l: int, m: int):
     # to learn more about what Cartesian order is, see https://e3x.readthedocs.io/stable/pitfalls.html
     # TLDR: it's the order in which we index the coefficients of a spherical harmonic function

--- a/utils/dummy_data_utils.py
+++ b/utils/dummy_data_utils.py
@@ -1,0 +1,22 @@
+import torch
+
+from irrep import Irreps
+
+
+def dummy_data(l: int) -> torch.Tensor:
+    # creates dummy data for a specific l value
+    arr = torch.zeros(2 * l + 1)
+    arr[0] = 1  # so the array is normalized to length 1
+    return arr
+
+
+def create_dummy_data_for_multiple_irreps(l_list: list[int]) -> torch.Tensor:
+    return [dummy_data(l) for l in l_list]
+
+
+def create_irreps_with_dummy_data(id: str) -> Irreps:
+    data_out = []
+    for _irreps_def, num_irreps, l, _parity in Irreps.parse_id(id):
+        for _ in range(num_irreps):
+            data_out.append(dummy_data(l))
+    return Irreps.from_id(id, data_out)

--- a/utils/dummy_data_utils.py
+++ b/utils/dummy_data_utils.py
@@ -10,10 +10,6 @@ def dummy_data(l: int) -> torch.Tensor:
     return arr
 
 
-def create_dummy_data_for_multiple_irreps(l_list: list[int]) -> torch.Tensor:
-    return [dummy_data(l) for l in l_list]
-
-
 def create_irreps_with_dummy_data(id: str) -> Irreps:
     data_out = []
     for _irreps_def, num_irreps, l, _parity in Irreps.parse_id(id):

--- a/utils/spherical_harmonics_utils.py
+++ b/utils/spherical_harmonics_utils.py
@@ -9,19 +9,20 @@ def parity_for_l(l: int) -> int:
     # PERF: reduce this to one line
     # return (l % 2)*(-2) + 1
 
+
 def parity_to_str(parity: int) -> str:
     return "e" if parity == EVEN_PARITY else "o"
+
 
 def to_cartesian_order_idx(l: int, m: int):
     # to learn more about what Cartesian order is, see https://e3x.readthedocs.io/stable/pitfalls.html
     # TLDR: it's the order in which we index the coefficients of a spherical harmonic function
     abs_m = abs(m)
-    num_m_in_l = 2*l + 1
+    num_m_in_l = 2 * l + 1
 
     if m == 0:
         return num_m_in_l - 1
     elif m < 0:
-        return num_m_in_l - 1 - 2*abs_m + 1
+        return num_m_in_l - 1 - 2 * abs_m + 1
     else:
-        return num_m_in_l - 1 - 2*abs_m
-
+        return num_m_in_l - 1 - 2 * abs_m


### PR DESCRIPTION
- a great way to apply this linear layer is right after the tensor product. This will simulate the full tensor product that e3nn has
- we can also use this layer to filter out representations that we don't care about. There is currently no bias. only linear weights
- simplified irreps tests with new dummy data functions